### PR TITLE
Run builtin game using an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,3 @@ $ make install
 ```
 
 On Gentoo Linux memwatch is available in portage: sys-process/memwatch
-
-## Screenshots ##
-![ScreenShot](https://unixdev.ru/wp-content/uploads/2016/05/memwatch.png)
-![ScreenShot](https://unixdev.ru/wp-content/uploads/2016/05/mw1.png)
-![ScreenShot](https://unixdev.ru/wp-content/uploads/2016/05/mw2.png)

--- a/src/common.c
+++ b/src/common.c
@@ -203,7 +203,7 @@ int dirname_only_digits(const char *name)
     return res;
 }
 
-static void do_hidden_game(void)
+void do_hidden_game(void)
 {
     struct tube {
         int len;

--- a/src/common.h
+++ b/src/common.h
@@ -11,5 +11,6 @@ void grep_digits(char *dst, const char *src, size_t len);
 int dirname_only_digits(const char *name);
 void print_hotkeys_help(void);
 void err_exit(const char *fmt, ...);
+void do_hidden_game(void);
 
 #endif /* COMMON_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,15 @@ int main(int argc, char **argv)
             err_exit("alloc failed: %s", strerror(errno));
     }
 
+    if (options.flags & GAME_FL)
+    {
+        do_hidden_game();
+        mvhline(LINES - 1, 0, ' ', COLS);
+        refresh();
+        endwin();
+        return 0;
+    }
+
     while (!quit)
     {
         wchar_t ch = 0;

--- a/src/memwatch.h
+++ b/src/memwatch.h
@@ -61,7 +61,8 @@ enum {
     SORT_SHM_FL  = 1 << 13,
     SORT_VIR_FL  = 1 << 14,
     SORT_SWP_FL  = 1 << 15,
-    SINGLE_PS_FL = 1 << 16
+    SINGLE_PS_FL = 1 << 16,
+    GAME_FL      = 1 << 17
 };
 
 enum {

--- a/src/options.c
+++ b/src/options.c
@@ -46,11 +46,12 @@ void parse_options(int argc, char *const argv[],
         { "list",    no_argument,       NULL, 'l'         },
         { "pid",     required_argument, NULL, 'p'         },
         { "version", no_argument,       NULL, 'V'         },
+        { "game",    no_argument,       NULL, 'e'         },
         { "help",    no_argument,       NULL, HELP_OPTION },
         { NULL, 0, NULL, 0                                }
     };
 
-    while ((opt = getopt_long(argc, argv, "d:p:SbkmgthlV", longopts, NULL)) != -1)
+    while ((opt = getopt_long(argc, argv, "d:p:SbkmgthlVe", longopts, NULL)) != -1)
     {
         switch (opt)
         {
@@ -130,6 +131,10 @@ void parse_options(int argc, char *const argv[],
             case 'V':
                 printf("%s v%s\n", PACKAGENAME, VERSION);
                 exit(EXIT_SUCCESS);
+
+            case 'e':
+                options->flags |= GAME_FL;
+                break;
 
             case HELP_OPTION:
                 print_help(stdout);


### PR DESCRIPTION
memwatch contains an easter game that can be started in runtime using
hotkey. Sometime it is convenient to start game without running memwatch
itself. Patch introduced a hidden option '-e' (easter egg) that starts a
game.